### PR TITLE
Updated CLI example for delete_tables.py

### DIFF
--- a/delete_tables.py
+++ b/delete_tables.py
@@ -1,7 +1,7 @@
 """
 Example Usage:
 
-    $ python delete_tables.py machine_learning_dev_ttl_30d.test_dataflow_2016_01_01_current2*
+    $ python delete_tables.py "machine_learning_dev_ttl_30d.test_dataflow_2016_01_01_current2*"
     Found the following matching tables:
     test_dataflow_2016_01_01_current20120101
     test_dataflow_2016_01_01_current20120102


### PR DESCRIPTION
The command line example needs quotes around table name in order to work. Not sure if this changed at some point or if it was always like this, but I updated the example to avoid confusion.